### PR TITLE
Allow Faster processing of wav files on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ can be done with the following command:
 
 <kbd>M-x package-install [RET] poweshell [RET]</kbd>
 
-When this is installed, `sound-wav` will create an shell process named
-`*sound-wav-powershell*` to play sounds without needing to start
-poweshell multiple times.  For me this changes a 1-2 second delay in
-sounds to immediate sound processing.
+When this is installed, `sound-wav` will create a hidden shell process
+named `* sound-wav-powershell*` to play sounds without needing to
+start poweshell multiple times.  For me this changes a 1-2 second
+delay in sounds to immediate sound processing.
 
 ## Interface
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ You can install `sound-wav` with the following command.
 
 <kbd>M-x package-install [RET] sound-wav [RET]</kbd>
 
+To speed up sound playing in windows, make sure
+[powershell](https://msdn.microsoft.com/en-us/powershell/mt173057.aspx)
+is installed, and then install the emacs package `powershell`.  This
+can be done with the following command:
+
+<kbd>M-x package-install [RET] poweshell [RET]</kbd>
+
+When this is installed, `sound-wav` will create an shell process named
+`*sound-wav-powershell*` to play sounds without needing to start
+poweshell multiple times.  For me this changes a 1-2 second delay in
+sounds to immediate sound processing.
 
 ## Interface
 

--- a/sound-wav.el
+++ b/sound-wav.el
@@ -47,9 +47,9 @@
 	 (or sound-wav--powershell-process
 	     (let ((buf (current-buffer)))
 	       (and 
-		(powershell "*sound-wav-powershell*")
+		(powershell " *sound-wav-powershell*")
 		(pop-to-buffer-same-window buf)
-		(setq sound-wav--powershell-process (get-buffer-process (get-buffer "*sound-wav-powershell*")))
+		(setq sound-wav--powershell-process (get-buffer-process (get-buffer " *sound-wav-powershell*")))
 		(set-process-query-on-exit-flag sound-wav--powershell-process nil)
 		sound-wav--powershell-process))))))
 

--- a/sound-wav.el
+++ b/sound-wav.el
@@ -30,9 +30,41 @@
 
 (require 'deferred)
 
+(when (memq system-type '(windows-nt ms-dos))
+  (require 'powershell nil t))
+
 (defgroup sound-wav nil
   "Play wav file"
   :group 'sound)
+
+(defvar sound-wav--powershell-process nil)
+(defsubst sound-wav--powershell-sound-player-process-p ()
+  "Create a powershell process to play windows files?"
+  (and (memq system-type '(windows-nt ms-dos))
+       (fboundp 'powershell)
+       (executable-find "powershell")
+       (save-excursion
+	 (or sound-wav--powershell-process
+	     (let ((buf (current-buffer)))
+	       (and 
+		(powershell "*sound-wav-powershell*")
+		(pop-to-buffer-same-window buf)
+		(setq sound-wav--powershell-process (get-buffer-process (get-buffer "*sound-wav-powershell*")))
+		(set-process-query-on-exit-flag sound-wav--powershell-process nil)
+		sound-wav--powershell-process))))))
+
+(defun sound-wav--do-play-by-powershell-process (files)
+  (and sound-wav--powershell-process
+       (comint-send-string sound-wav--powershell-process
+			   (concat (mapconcat
+				    (lambda (file)
+				      (format "(New-Object Media.SoundPlayer \"%s\").PlaySync()"
+					      file))
+				    files
+				    "\n") "\n"))))
+
+;; Start powershell process to immediately parse sounds..
+(sound-wav--powershell-sound-player-process-p)
 
 (defsubst sound-wav--powershell-sound-player-p ()
   "Is powershell available to play windows files?"
@@ -81,7 +113,9 @@
     (apply 'deferred:process "aplay" files)))
 
 (defun sound-wav--do-play (files)
-  (cond ((sound-wav--powershell-sound-player-p)
+  (cond ((sound-wav--powershell-sound-player-process-p)
+	 (sound-wav--do-play-by-powershell-process files))
+	((sound-wav--powershell-sound-player-p)
 	 (sound-wav--do-play-by-powershell files))
 	((sound-wav--window-media-player-p)
          (sound-wav--do-play-by-wmm files))


### PR DESCRIPTION
By using `powershell` and the emacs package `powershell`, immediate wav playback can be achieved.
