### PR TITLE
Use a powershell process when available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ You can install `sound-wav` with the following command.
 
 <kbd>M-x package-install [RET] sound-wav [RET]</kbd>
 
+To speed up sound playing in windows, make sure
+[powershell](https://msdn.microsoft.com/en-us/powershell/mt173057.aspx)
+is installed, and then install the emacs package `powershell`.  This
+can be done with the following command:
+
+<kbd>M-x package-install [RET] poweshell [RET]</kbd>
+
+When this is installed, `sound-wav` will create a hidden shell process
+named `* sound-wav-powershell*` to play sounds without needing to
+start poweshell multiple times.  For me this changes a 1-2 second
+delay in sounds to immediate sound processing.
 
 ## Interface
 

--- a/sound-wav.el
+++ b/sound-wav.el
@@ -30,9 +30,41 @@
 
 (require 'deferred)
 
+(when (memq system-type '(windows-nt ms-dos))
+  (require 'powershell nil t))
+
 (defgroup sound-wav nil
   "Play wav file"
   :group 'sound)
+
+(defvar sound-wav--powershell-process nil)
+(defsubst sound-wav--powershell-sound-player-process-p ()
+  "Create a powershell process to play windows files?"
+  (and (memq system-type '(windows-nt ms-dos))
+       (fboundp 'powershell)
+       (executable-find "powershell")
+       (save-excursion
+	 (or sound-wav--powershell-process
+	     (let ((buf (current-buffer)))
+	       (and 
+		(powershell " *sound-wav-powershell*")
+		(pop-to-buffer-same-window buf)
+		(setq sound-wav--powershell-process (get-buffer-process (get-buffer " *sound-wav-powershell*")))
+		(set-process-query-on-exit-flag sound-wav--powershell-process nil)
+		sound-wav--powershell-process))))))
+
+(defun sound-wav--do-play-by-powershell-process (files)
+  (and sound-wav--powershell-process
+       (comint-send-string sound-wav--powershell-process
+			   (concat (mapconcat
+				    (lambda (file)
+				      (format "(New-Object Media.SoundPlayer \"%s\").PlaySync()"
+					      file))
+				    files
+				    "\n") "\n"))))
+
+;; Start powershell process to immediately parse sounds..
+(sound-wav--powershell-sound-player-process-p)
 
 (defsubst sound-wav--powershell-sound-player-p ()
   "Is powershell available to play windows files?"
@@ -54,6 +86,8 @@
 (defsubst sound-wav--window-media-player-p ()
   (and (executable-find "ruby")
        (memq system-type '(windows-nt ms-dos))))
+
+
 
 (defun sound-wav--do-play-by-wmm (files)
   (deferred:$
@@ -79,9 +113,11 @@
     (apply 'deferred:process "aplay" files)))
 
 (defun sound-wav--do-play (files)
-  (cond ((sound-wav--powershell-sound-player-p)
-         (sound-wav--do-play-by-powershell files))
-        ((sound-wav--window-media-player-p)
+  (cond ((sound-wav--powershell-sound-player-process-p)
+	 (sound-wav--do-play-by-powershell-process files))
+	((sound-wav--powershell-sound-player-p)
+	 (sound-wav--do-play-by-powershell files))
+	((sound-wav--window-media-player-p)
          (sound-wav--do-play-by-wmm files))
         ((executable-find "afplay")
          (sound-wav--do-play-by-afplay files))


### PR DESCRIPTION
- This powershell process is hidden
- This poweshell process is automatically killed when exiting emacs (no
  prompt needed)
- Currently this needs the powershell emacs package.
