### PR TITLE
OpenBSD aucat support

### DIFF
--- a/sound-wav.el
+++ b/sound-wav.el
@@ -126,8 +126,8 @@
  "Not documented."
   (deferred:$
     (deferred:process-shell
-      (format "printf \"%s\" | sed 's/^/aucat -i /' | sh"
-              (mapconcat 'identity files "\n")))))
+      (format "printf \"%s\n\" | sed 's/^/aucat -i /' | sh"
+              (mapconcat 'identity files)))))
  	  
 (defun sound-wav--do-play (files)
   "Not documented."

--- a/sound-wav.el
+++ b/sound-wav.el
@@ -122,6 +122,13 @@
   (deferred:$
     (apply 'deferred:process "aplay" files)))
 
+(defun sound-wav--do-play-by-aucat (files)
+ "Not documented."
+  (deferred:$
+    (deferred:process-shell
+      (format "printf \"%s\" | sed 's/^/aucat -i /' | sh"
+              (mapconcat 'identity files "\n")))))
+ 	  
 (defun sound-wav--do-play (files)
   "Not documented."
   (cond ((sound-wav--powershell-sound-player-process-p)
@@ -134,6 +141,8 @@
          (sound-wav--do-play-by-afplay files))
         ((executable-find "aplay")
          (sound-wav--do-play-by-aplay files))
+	((executable-find "aucat")
+	 (sound-wav--do-play-by-aucat files))
         (t
          (error "Not found wav player on your system!!"))))
 


### PR DESCRIPTION
I added support for OpenBSD [aucat](https://man.openbsd.org/aucat.1).
It is default audio manipulation tool on OpenBSD and i use emacs on OpenBSD.

There is one package that i use that depends on this package — [org-pomodoro](https://github.com/marcinkoziej/org-pomodoro).

Unfortunately, i can't use `M-x play-sound-file` because emacs prompt me to `This Emacs binary lacks sound support`
and emacs makefile in ports contains `--without-sound` in `CONFIGURE_ARGS`.

Frankly speaking that aucat playing part was copied almost entirely from Mac OS X `afplay` version.
The only difference that in shell command was used:
1. `printf` instead of `echo`, because it gives me ability to put newline into shell command
2. `sed` instead of `awk`, because i didnt want to have two `\"` in one awk command.

There was also some warnings or something (i am an newbie in elisp) in deferred part:
https://termbin.com/yxk2i
```
#s(deferred #[257 "r�q�� )�!��" [buffer-string kill-buffer] 4 "

(fn BUF)"] deferred:default-errorback #[257 "���!���!�" [(#0) #s(deferred deferred:default-callback deferred:default-errorback deferred:default-cancel #0 nil nil) deferred:default-cancel] 3 "

(fn X)"] nil nil nil)
```
 
But when i use org-pomodoro with my fork of this repo this message just don't show up:
There is nothing about it in Messages buffer.

That's it, i think. Sorry, if something spelled wrong, English is not my mother tongue.

P.S.
Mind if I try to add `ffplay` ? It is part of ffmpeg and ffmpeg seems to be ported almost everywhere.